### PR TITLE
Add support for an angular workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ nx-lib-bundle is a minimalistic attempt at bundling NX workspace libraries in in
 
 Upon execution `nx-lib-bundle` will performs the following tasks:
 
-* Look for `nx.json`, `workspace.json` and `package.json`
+* Look for `workspace.json` or `angular.json` and `nx.json` , `package.json`
 * Build node package files in `dist` with the npmScope and project name
 * Use the version number of `package.json`
 * If a `package-template.json` is found in the workspace root, then its content will be added to the generated `package.json`

--- a/src/nx.ts
+++ b/src/nx.ts
@@ -78,7 +78,7 @@ export class Nx {
         for (;;) {
             if (hasFiles(dir, 'workspace.json', 'package.json', 'nx.json')) {
                 projectType = 'workspace'
-            } else             if (hasFiles(dir, 'angular.json', 'package.json', 'nx.json')) {
+            } else if (hasFiles(dir, 'angular.json', 'package.json', 'nx.json')) {
                 projectType = 'angular'
             }
             if (projectType) {

--- a/src/nx.ts
+++ b/src/nx.ts
@@ -73,13 +73,19 @@ export class Nx {
 
     constructor(public output: string) {
         let dir = process.cwd();
+        let projectType = undefined
 
         for (;;) {
             if (hasFiles(dir, 'workspace.json', 'package.json', 'nx.json')) {
+                projectType = 'workspace'
+            } else             if (hasFiles(dir, 'angular.json', 'package.json', 'nx.json')) {
+                projectType = 'angular'
+            }
+            if (projectType) {
                 this.baseDir = dir;
                 this.package = this.readJSON('package.json');
                 this.nx = this.readJSON('nx.json');
-                this.workspace = this.readJSON('workspace.json');
+                this.workspace = this.readJSON(projectType + '.json');
                 this.scope = ('@' + this.nx.npmScope) as string;
 
                 copyEntries(this.dependencies, this.package, 'peerDependencies');


### PR DESCRIPTION
A proposal for #1
If you setup your workspace with an angular project, nx creates an `angular.json` file instead of a `workspace.json` file. 
